### PR TITLE
Lock pretender js at 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "pretender": "^1.4.2",
+    "pretender": "~1.4.2",
     "type-factory": "^1.0.5",
     "underscore": "^1.8.3"
   }


### PR DESCRIPTION
Route recognizer is updated on commit https://github.com/pretenderjs/pretender/commit/2c5df2df37e0c953f2232d1021b4abc24a582a3a which breaks fake server.