### PR TITLE
Set 'content-type' to 'application/vnd.api+json' as by specs

### DIFF
--- a/src/baseController.js
+++ b/src/baseController.js
@@ -128,7 +128,7 @@ module.exports = typeFactory({
 
         options = assign({
             statusCode: 200,
-            headers: {'Content-Type': 'application/json'},
+            headers: {'Content-Type': 'application/vnd.api+json'},
         }, options);
 
         return [options.statusCode, options.headers, JSON.stringify(data)];

--- a/src/server.js
+++ b/src/server.js
@@ -52,7 +52,7 @@ var Server = typeFactory({
             try {
                 response = callback(request);
             } catch (e) {
-                response = [500, {'Content-Type': 'application/json'}, e.toString()];
+                response = [500, {'Content-Type': 'application/vnd.api+json'}, e.toString()];
             }
             self.trigger('response', response);
             return response;


### PR DESCRIPTION
@dbrekalo: Congrats for this well crafted \*JSONAPI mocking solution, it's simply the most well thought solution out there, and I'm rather sure I tried them all. Didn't make use of the in-browser option so far, but that's a smart one and might get handy! 🤩🥳

As the [specs](https://jsonapi.org/format/1.0/#introduction) require, this PR changes the header content-type from ```application/json``` to ```application/vnd.api+json```

I ran into this while setting it up with [Orbit JS](https://github.com/orbitjs/orbit), which just gave me a vague ```TypeError: undefined is not an object (evaluating 'document.data') — jsonapi-serializer.js:128```, until I found the issue being the content-type set to 'application/json'.

***\**** I generally tend to write JSONAPI, to make it distinkt from all that "something JSON API" out there.

Cheers,
*Black*